### PR TITLE
feat: add IUserPasskeyStore support and separate tokens collection

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "10.0.100",
     "rollForward": "latestMinor",
     "allowPrerelease": false
   }

--- a/src/Core/IdentityMongoVault.cs
+++ b/src/Core/IdentityMongoVault.cs
@@ -37,4 +37,5 @@ public abstract class IdentityMongoVault<TUser, TRole, TKey> : MongoVault
 
     public DocumentSet<TUser> Users { get; set; } = null!;
     public DocumentSet<TRole> Roles { get; set; } = null!;
+    public DocumentSet<MongoUserToken<TKey>> UserTokens { get; set; } = null!;
 }

--- a/src/Core/Models/MongoUser.cs
+++ b/src/Core/Models/MongoUser.cs
@@ -10,5 +10,5 @@ public class MongoUser<TKey> : IdentityUser<TKey> where TKey : IEquatable<TKey>
     public ICollection<TKey> Roles { get; set; } = new List<TKey>();
     public ICollection<IdentityUserClaim<TKey>> Claims { get; set; } = new List<IdentityUserClaim<TKey>>();
     public ICollection<IdentityUserLogin<TKey>> Logins { get; set; } = new List<IdentityUserLogin<TKey>>();
-    public ICollection<IdentityUserToken<TKey>> Tokens { get; set; } = new List<IdentityUserToken<TKey>>();
+    public ICollection<IdentityUserPasskey<TKey>> Passkeys { get; set; } = new List<IdentityUserPasskey<TKey>>();
 }

--- a/src/Core/Models/MongoUserToken.cs
+++ b/src/Core/Models/MongoUserToken.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Identity;
+using MongoDB.Bson;
+
+namespace MongoFlow.Identity;
+
+public class MongoUserToken : MongoUserToken<ObjectId>;
+
+public class MongoUserToken<TKey> : IdentityUserToken<TKey> where TKey : IEquatable<TKey>
+{
+    public TKey Id { get; set; } = default!;
+}
+

--- a/src/Core/Models/MongoUserToken.cs
+++ b/src/Core/Models/MongoUserToken.cs
@@ -5,8 +5,4 @@ namespace MongoFlow.Identity;
 
 public class MongoUserToken : MongoUserToken<ObjectId>;
 
-public class MongoUserToken<TKey> : IdentityUserToken<TKey> where TKey : IEquatable<TKey>
-{
-    public TKey Id { get; set; } = default!;
-}
-
+public class MongoUserToken<TKey> : IdentityUserToken<TKey> where TKey : IEquatable<TKey>;

--- a/src/Core/MongoFlow.Identity.csproj
+++ b/src/Core/MongoFlow.Identity.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Title>MongoFlow.Identity</Title>
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="10.0.1" />
     <PackageReference Include="MongoFlow" Version="0.5.4" />
   </ItemGroup>
 


### PR DESCRIPTION
BREAKING CHANGE: User tokens are now stored in a separate UserTokens collection instead of being embedded in user documents.

Changes:
- Implement IUserPasskeyStore<TUser> with full passkey support
- Add MongoUserToken<TKey> model inheriting IdentityUserToken<TKey>
- Move tokens from embedded documents to UserTokens collection
- Add UserTokens DocumentSet to IdentityMongoVault
- Implement FindUserLoginAsync for external login lookups
- Add .NET 10 target framework support

New files:
- src/Core/Models/MongoUserToken.cs

Modified files:
- src/Core/Models/MongoUser.cs (added Passkeys, removed Tokens)
- src/Core/Stores/MongoUserStore.cs (passkey + token refactor)
- src/Core/IdentityMongoVault.cs (added UserTokens)
- src/Core/MongoFlow.Identity.csproj (added net10.0)