### PR TITLE
feat(models): add Id property to MongoUserToken

### DIFF
--- a/src/Core/Models/MongoUserToken.cs
+++ b/src/Core/Models/MongoUserToken.cs
@@ -5,4 +5,7 @@ namespace MongoFlow.Identity;
 
 public class MongoUserToken : MongoUserToken<ObjectId>;
 
-public class MongoUserToken<TKey> : IdentityUserToken<TKey> where TKey : IEquatable<TKey>;
+public class MongoUserToken<TKey> : IdentityUserToken<TKey> where TKey : IEquatable<TKey>
+{
+    public TKey Id { get; set; } = default!;
+}


### PR DESCRIPTION
Add Id property to MongoUserToken<TKey> class to support MongoDB document identification, as the base IdentityUserToken<TKey> class doesn't include a primary key field.