### PR TITLE
fix: correct user token BSON mapping and add passkey registration

### DIFF
--- a/src/Core/Configurations/MongoIdentityConfiguration.cs
+++ b/src/Core/Configurations/MongoIdentityConfiguration.cs
@@ -31,11 +31,11 @@ internal static class MongoIdentityConfiguration
             map.UnmapProperty(x => x.UserId);
         });
         
-        BsonClassMap.TryRegisterClassMap<IdentityUserToken<TKey>>(map =>
+        BsonClassMap.TryRegisterClassMap<MongoUserToken<TKey>>(map =>
         {
             map.AutoMap();
             map.SetIgnoreExtraElements(true);
-            map.UnmapProperty(x => x.UserId);
+            map.UnmapProperty(x => x.Id);
         });
         
         BsonClassMap.TryRegisterClassMap<IdentityRoleClaim<TKey>>(map =>
@@ -44,6 +44,13 @@ internal static class MongoIdentityConfiguration
             map.SetIgnoreExtraElements(true);
             map.UnmapProperty(x => x.Id);
             map.UnmapProperty(x => x.RoleId);
+        });
+        
+        BsonClassMap.TryRegisterClassMap<IdentityUserPasskey<TKey>>(map =>
+        {
+            map.AutoMap();
+            map.SetIgnoreExtraElements(true);
+            map.UnmapProperty(x => x.UserId);
         });
     }
     


### PR DESCRIPTION
- Use MongoUserToken<TKey> instead of IdentityUserToken<TKey>
- Unmap Id property instead of UserId for token mapping
- Add missing BsonClassMap for IdentityUserPasskey<TKey>