### PR TITLE
fix(user-store): override SetTokenAsync to properly update existing t…

### DIFF
--- a/src/Core/Stores/MongoUserStore.cs
+++ b/src/Core/Stores/MongoUserStore.cs
@@ -605,6 +605,25 @@ public class MongoUserStore<TVault, TUser, TRole, TKey> :
         
         return Task.CompletedTask;
     }
+    
+    public override async Task SetTokenAsync(TUser user, string loginProvider, string name, string? value, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+
+        ArgumentNullException.ThrowIfNull(user);
+
+        var token = await FindTokenAsync(user, loginProvider, name, cancellationToken).ConfigureAwait(false);
+        if (token == null)
+        {
+            await AddUserTokenAsync(CreateUserToken(user, loginProvider, name, value)).ConfigureAwait(false);
+        }
+        else
+        {
+            token.Value = value;
+            _userTokens.Replace(token);
+        }
+    }
 }
 
 public interface ICloneUserStore<TUser> where TUser : class


### PR DESCRIPTION
…okens

The base implementation was not correctly handling token updates. Now tokens are replaced when they already exist instead of duplicating.